### PR TITLE
Stabilize DGM control flow and run metadata

### DIFF
--- a/DGM_outer.py
+++ b/DGM_outer.py
@@ -4,6 +4,7 @@ import json
 import math
 import os
 import random
+import shutil
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, as_completed, TimeoutError
 
 from prompts.self_improvement_prompt import find_selfimprove_eval_logs
@@ -26,9 +27,10 @@ def initialize_run(output_dir, prevrun_dir=None, polyglot=False):
 
     # Copy cached initial version into experiment dir
     initial_folder_name = 'initial' if not polyglot else 'initial_polyglot'
-    if not prevrun_dir and not os.path.exists(f"{output_dir}/{initial_folder_name}"):
+    target_initial_dir = os.path.join(output_dir, "initial")
+    if not prevrun_dir and not os.path.exists(target_initial_dir):
         if os.path.exists(initial_folder_name):
-            os.system(f"cp -r {initial_folder_name}/ {output_dir}/initial")
+            shutil.copytree(initial_folder_name, target_initial_dir)
         else:
             raise RuntimeError("Error: Need to properly configure evaluation results for the initial version.")
     
@@ -75,6 +77,9 @@ def choose_selfimproves(output_dir, archive, selfimprove_size, method='random', 
             print(f"{commit} not eligible for being a parent: {e}")
             continue
 
+    if not candidates:
+        return []
+
     # Choose parents based on method and baseline
     if run_baseline == 'no_darwin':
         # Always take the last commit
@@ -100,7 +105,7 @@ def choose_selfimproves(output_dir, archive, selfimprove_size, method='random', 
         parent_commits = random.choices(commits, probabilities, k=selfimprove_size)
     elif method == 'best':
         # Choose parents with the best score
-        sorted_commits = sorted(candidates, key=lambda x: candidates[x]['accuracy_score'])
+        sorted_commits = sorted(candidates, key=lambda x: candidates[x]['accuracy_score'], reverse=True)
         parent_commits = sorted_commits[:min(selfimprove_size, len(sorted_commits))]
         if len(parent_commits) < selfimprove_size:
             parent_commits.extend(random.choices(parent_commits, k=selfimprove_size - len(parent_commits)))
@@ -141,7 +146,7 @@ def choose_selfimproves(output_dir, archive, selfimprove_size, method='random', 
                 continue
 
             # Choose a random unresolved entry
-            if unresolved_ids == 0:
+            if not unresolved_ids:
                 continue
             entry_ids = unresolved_ids
         entry = random.choice(entry_ids)
@@ -225,7 +230,7 @@ def main():
     parser.add_argument("--selfimprove_workers", type=int, default=2, help="Number of parallel workers for self-improvement attempts.")
     parser.add_argument(
         "--choose_selfimproves_method", type=str, default='score_child_prop',
-        choices=['random', 'score_prop', 'score_child_prop' 'best'],
+        choices=['random', 'score_prop', 'score_child_prop', 'best'],
         help="Method to choose self-improve attempts.",
     )
     parser.add_argument("--continue_from", type=str, default=None, help="Directory to continue the run from.")
@@ -237,6 +242,7 @@ def main():
     parser.add_argument("--polyglot", default=False, action='store_true', help="Run single shallow evaluation for self-improvement on swe.")
     parser.add_argument("--eval_noise", type=float, default=0.1, help="Noise leeway for evaluation.")
     parser.add_argument("--no_full_eval", default=False, action='store_true', help="Do not run full evaluation on swe if a node is the top N highest performing.")
+    parser.add_argument("--seed", type=int, default=None, help="Random seed for reproducible parent and entry selection.")
     # baselines
     parser.add_argument("--run_baseline", type=str, default=None, choices=['no_selfimprove', 'no_darwin'], help="Baseline to run.")
     args = parser.parse_args()
@@ -263,8 +269,11 @@ def main():
 
     # Set up logger
     logger = setup_logger(os.path.join(output_dir, "dgm_outer.log"))
+    if args.seed is not None:
+        random.seed(args.seed)
     logger.info(f"Starting DGM run {run_id} with arguments: {vars(args)}")
     logger.info(f"Archive: {archive}")
+    logger.info(f"Random seed: {args.seed}")
     test_more_threshold = 0.4
     # Run the DGM
     for gen_num in range(start_gen_num, args.max_generation):
@@ -279,8 +288,10 @@ def main():
 
         # Run self-improvement processes
         selfimprove_ids = []
+        failed_attempts = []
+        full_eval_threshold = None if args.no_full_eval else get_full_eval_threshold(output_dir, archive)
         with ThreadPoolExecutor(max_workers=args.selfimprove_workers) as executor:
-            futures = [
+            future_to_attempt = {
                 executor.submit(
                     self_improve,
                     parent_commit=parent_commit,
@@ -293,24 +304,33 @@ def main():
                     test_more_threshold=None if args.shallow_eval else test_more_threshold,
                     test_task_list_more=None if args.shallow_eval else swe_issues_med,
                     polyglot=args.polyglot,
-                    full_eval_threshold=None if args.no_full_eval else get_full_eval_threshold(output_dir, archive),
+                    full_eval_threshold=full_eval_threshold,
                     run_baseline=args.run_baseline,
-                )
+                    dgm_run_id=run_id,
+                    generation=gen_num,
+                ): {"parent_commit": parent_commit, "entry": entry}
                 for parent_commit, entry in selfimprove_entries
-            ]
+            }
 
-            for future in as_completed(futures):
+            for future in as_completed(future_to_attempt):
+                attempt = future_to_attempt[future]
                 try:
                     # Added timeout to avoid hanging indefinitely (1.5 h here)
                     metadata = future.result(timeout=1.5*60*60)
                     selfimprove_ids.append(metadata['run_id'])
                 except TimeoutError:
-                    logger.error("Self-improvement attempt timed out.")
+                    logger.error(f"Self-improvement attempt timed out: {attempt}")
                     future.cancel()  # Optionally cancel the future if it's still running
+                    failed_attempts.append({**attempt, "error_type": "timeout"})
                 except Exception as e:
                     import traceback
-                    logger.error(f"Self-improvement step failed: {e}")
+                    logger.error(f"Self-improvement step failed for {attempt}: {e}")
                     logger.error(f"Traceback:\n{traceback.format_exc()}")
+                    failed_attempts.append({
+                        **attempt,
+                        "error_type": "exception",
+                        "error": str(e),
+                    })
 
         # Update archive
         logger.info(f"Updating archive for generation {gen_num}")
@@ -325,9 +345,12 @@ def main():
         with open(os.path.join(output_dir, "dgm_metadata.jsonl"), "a") as f:
             f.write(json.dumps({
                 "generation": gen_num,
+                "seed": args.seed,
                 "selfimprove_entries": selfimprove_entries,
                 "children": selfimprove_ids,
                 "children_compiled": selfimprove_ids_compiled,
+                "children_failed": failed_attempts,
+                "full_eval_threshold": full_eval_threshold,
                 "archive": archive,
             }, indent=2) + "\n")
 

--- a/llm_withtools.py
+++ b/llm_withtools.py
@@ -80,11 +80,11 @@ def check_for_tool_use(response, model=''):
 
     elif model.startswith('o3-'):
         # OpenAI, check for tool_calls in response
-        for tool_call in response.output:
-            if tool_call.type == "function_call":
-                break
-
-        if tool_call:
+        tool_call = next(
+            (output_item for output_item in response.output if output_item.type == "function_call"),
+            None,
+        )
+        if tool_call is not None:
             return {
                 'tool_id': tool_call.call_id,
                 'tool_name': tool_call.name,
@@ -330,8 +330,8 @@ def chat_with_agent_manualtools(msg, model, msg_history=None, logging=print):
             # Check for next tool use
             tool_use = check_for_tool_use(response, model=client_model)
 
-    except Exception:
-        pass
+    except Exception as e:
+        logging(f"Error in chat_with_agent_manualtools: {e}")
 
     return new_msg_history
 
@@ -419,8 +419,8 @@ def chat_with_agent_claude(
             ],
         })
 
-    except Exception:
-        pass
+    except Exception as e:
+        logging(f"Error in chat_with_agent_claude: {e}")
 
     return new_msg_history
 
@@ -506,8 +506,8 @@ def chat_with_agent_openai(
         # Get final response
         new_msg_history.append(response)
 
-    except Exception:
-        pass
+    except Exception as e:
+        logging(f"Error in chat_with_agent_openai: {e}")
 
     return new_msg_history
 

--- a/self_improve_step.py
+++ b/self_improve_step.py
@@ -2,6 +2,7 @@ import argparse
 import datetime
 import json
 import os
+import traceback
 import docker
 
 from llm import create_client, get_response_from_llm, extract_json_between_markers
@@ -26,6 +27,27 @@ from utils.docker_utils import (
 
 dataset = None
 diagnose_model = 'o1-2024-12-17'
+
+def _utcnow():
+    return datetime.datetime.utcnow().isoformat(timespec='seconds') + "Z"
+
+def _start_phase(metadata, phase_name):
+    metadata['current_phase'] = phase_name
+    metadata.setdefault('phase_timings', {})[phase_name] = {
+        "started_at": _utcnow(),
+    }
+
+def _finish_phase(metadata, phase_name):
+    phase_metadata = metadata.setdefault('phase_timings', {}).setdefault(phase_name, {})
+    phase_metadata["finished_at"] = _utcnow()
+
+def _record_error(metadata, phase_name, error):
+    metadata.setdefault('errors', []).append({
+        "phase": phase_name,
+        "error": str(error),
+        "traceback": traceback.format_exc(),
+        "recorded_at": _utcnow(),
+    })
 
 def diagnose_problem(entry, commit, root_dir, out_dir, patch_files=[], max_attempts=3, polyglot=False):
     client = create_client(diagnose_model)
@@ -122,7 +144,20 @@ def save_metadata(metadata, output_dir):
     with open(metadata_file, 'w') as f:
         json.dump(metadata, f, indent=4)
 
-def run_harness_swe(entry, model_name_or_path, patch_files, num_evals, output_dir, metadata, run_id, test_more_threshold, test_task_list, test_task_list_more):
+def run_harness_swe(
+    entry,
+    model_name_or_path,
+    patch_files,
+    num_evals,
+    output_dir,
+    metadata,
+    run_id,
+    test_more_threshold,
+    test_task_list,
+    test_task_list_more,
+    full_eval_threshold=None,
+    test_task_list_big=None,
+):
     safe_log('Start harness')
     test_task_list = [entry] if test_task_list is None else test_task_list
     dnames = harness(
@@ -176,6 +211,37 @@ def run_harness_swe(entry, model_name_or_path, patch_files, num_evals, output_di
         performances, overall_performance = get_all_performance(model_name_or_path, results_dir=output_dir)
         metadata['overall_performance'] = overall_performance
         safe_log("End of evaluation more")
+
+    if (
+        overall_performance and
+        full_eval_threshold is not None and
+        test_task_list_big is not None and
+        overall_performance.get('accuracy_score', 0) >= full_eval_threshold
+    ):
+        safe_log("Start full evaluation cycle")
+        dnames = harness(
+            test_task_list=test_task_list_big,
+            num_samples=-1,
+            max_workers=min(5, len(test_task_list_big)),
+            model_name_or_path=model_name_or_path,
+            model_patch_paths=patch_files,
+            num_evals=num_evals,
+            num_evals_parallel=5,
+            pred_dname=os.path.join(output_dir, "predictions"),
+        )
+        safe_log('Start make_report full')
+        make_report(
+            dnames,
+            run_ids=[f"{run_id}_{i}" for i in range(len(dnames))],
+            dataset_name="princeton-nlp/SWE-bench_Verified",
+            output_dir=output_dir,
+            dnames_workers=5,
+        )
+        safe_log('Start get_performance full')
+        performances, overall_performance = get_all_performance(model_name_or_path, results_dir=output_dir)
+        metadata['overall_performance'] = overall_performance
+        metadata['full_evaluation_ran'] = True
+        safe_log("End of evaluation full")
 
 def run_harness_polyglot(entry, model_name_or_path, patch_files, num_evals, output_dir, metadata, run_id, test_more_threshold, test_task_list, test_task_list_more):
     safe_log('Start harness')
@@ -234,7 +300,9 @@ def self_improve(
     full_eval_threshold=None,
     # Run baseline
     run_baseline=None,
-    polyglot=False
+    polyglot=False,
+    dgm_run_id=None,
+    generation=None,
 ):  
 
     global dataset
@@ -253,14 +321,31 @@ def self_improve(
     out_dir_base = output_dir  # out_dir_base should be /dgm/output_selfimprove/ or /dgm/output_dgm/{dgm_run_id}/
     output_dir = os.path.join(root_dir, f"{output_dir}/{run_id}/")
     os.makedirs(output_dir, exist_ok=True)
-    metadata['run_id'] = run_id
-    metadata['parent_commit'] = parent_commit
+    metadata.update({
+        'run_id': run_id,
+        'dgm_run_id': dgm_run_id,
+        'generation': generation,
+        'parent_commit': parent_commit,
+        'entry': entry,
+        'status': 'running',
+        'started_at': _utcnow(),
+        'errors': [],
+        'phase_timings': {},
+        'full_eval_threshold': full_eval_threshold,
+    })
     test_task_list_big = load_json_file("./swe_bench/subsets/big.json")
+
+    def finalize(status):
+        metadata['status'] = status
+        metadata['finished_at'] = _utcnow()
+        save_metadata(metadata, output_dir)
+        return metadata
 
     # Set up logger
     logger = setup_logger(os.path.join(output_dir, "self_improve.log"))
 
     # Create and start the Docker container
+    _start_phase(metadata, "docker_setup")
     image_name = "dgm"
     container_name = f"dgm-container-{run_id}"
     client = docker.from_env()
@@ -271,7 +356,11 @@ def self_improve(
         client, root_dir, image_name, container_name,
         force_rebuild=force_rebuild,
     )
-    container.start()
+    if container is None:
+        _record_error(metadata, "docker_setup", "Failed to build or start the DGM container")
+        _finish_phase(metadata, "docker_setup")
+        return finalize("docker_setup_failed")
+    _finish_phase(metadata, "docker_setup")
 
     if polyglot:
         # remove the swe version of coding_agent.py
@@ -315,25 +404,26 @@ def self_improve(
     # Get tasks to improve
     if entry:
         safe_log(f"Task to improve: {entry}")
+        _start_phase(metadata, "diagnose_problem")
         problem_statement = diagnose_problem(entry, parent_commit, root_dir, out_dir_base, patch_files=patch_files, polyglot=polyglot)
+        _finish_phase(metadata, "diagnose_problem")
         safe_log(f"problem_statement: {problem_statement}")
     else:
         safe_log("No entry provided. Exiting.")
         cleanup_container(container)
-        save_metadata(metadata, output_dir)
-        return metadata
+        return finalize("no_entry")
 
-    metadata['entry'] = entry
     metadata['problem_statement'] = problem_statement
     # If problem statement is not found, exit
     if not problem_statement:
         safe_log("Failed to diagnose the problem statement. Exiting.")
+        _record_error(metadata, "diagnose_problem", "Failed to diagnose the problem statement")
         cleanup_container(container)
-        save_metadata(metadata, output_dir)
-        return metadata
+        return finalize("diagnosis_failed")
 
     # Run self-improvement
     safe_log("Running self-improvement")
+    _start_phase(metadata, "agent_run")
     chat_history_file_container = "/dgm/self_evo.md"
     test_description = get_test_description(swerepo=False)
     env_vars = {
@@ -357,12 +447,15 @@ def self_improve(
     ]
     exec_result = container.exec_run(cmd, environment=env_vars, workdir='/')
     log_container_output(exec_result)
+    _finish_phase(metadata, "agent_run")
 
     # Copy output files back to host
+    _start_phase(metadata, "extract_artifacts")
     chat_history_file = os.path.join(output_dir, "self_evo.md")
     copy_from_container(container, chat_history_file_container, chat_history_file)
     model_patch_file = os.path.join(output_dir, "model_patch.diff")
     copy_from_container(container, "/dgm/model_patch.diff", model_patch_file)
+    _finish_phase(metadata, "extract_artifacts")
 
     # Try reading the patch file to validate it
     try:
@@ -375,8 +468,9 @@ def self_improve(
                 raise Exception("Model patch file is empty")
     except Exception as e:
         safe_log(f"Failed to read model patch file: {str(e)}")
-        save_metadata(metadata, output_dir)
-        return metadata
+        _record_error(metadata, "extract_artifacts", e)
+        cleanup_container(container)
+        return finalize("patch_extraction_failed")
 
     patch_files.append(model_patch_file)
 
@@ -391,16 +485,35 @@ def self_improve(
     model_name_or_path = run_id
     if model_patch_exists and model_patch_notempty:
         try:
+            _start_phase(metadata, "evaluation")
             if not polyglot:
-                run_harness_swe(entry, model_name_or_path, patch_files, num_evals, output_dir, metadata, run_id, test_more_threshold, test_task_list, test_task_list_more)
+                run_harness_swe(
+                    entry,
+                    model_name_or_path,
+                    patch_files,
+                    num_evals,
+                    output_dir,
+                    metadata,
+                    run_id,
+                    test_more_threshold,
+                    test_task_list,
+                    test_task_list_more,
+                    full_eval_threshold=full_eval_threshold,
+                    test_task_list_big=test_task_list_big,
+                )
             else:
                 run_harness_polyglot(entry, model_name_or_path, patch_files, num_evals, output_dir, metadata, run_id, test_more_threshold, test_task_list, test_task_list_more)
+            _finish_phase(metadata, "evaluation")
         except Exception as e:
             safe_log(f"Error while evaluating the self-improvement: {e}")
+            _record_error(metadata, "evaluation", e)
+            _finish_phase(metadata, "evaluation")
+            metadata['evaluation_error'] = str(e)
 
     # Post-self-improvement diagnosis
     if post_improve_diagnose:
         safe_log("Diagnosing the self-improvement")
+        _start_phase(metadata, "post_improve_diagnose")
         metadata['is_compiled'] = is_compiled_self_improve(metadata)
         if metadata['is_compiled']:
             safe_log("The self-improvement succeed to be complied")
@@ -414,10 +527,14 @@ def self_improve(
         else:
             safe_log("The self-improvement fail to be complied")
             metadata['improvement_diagnosis'] = "Fail to complied. Ignore this."
+        _finish_phase(metadata, "post_improve_diagnose")
 
     # Save metadata of this self-improvement attempt
-    save_metadata(metadata, output_dir)
-    return metadata
+    if metadata.get('evaluation_error'):
+        return finalize("evaluation_failed")
+    if not model_patch_exists or not model_patch_notempty:
+        return finalize("empty_model_patch")
+    return finalize("completed")
 
 def main():
     parser = argparse.ArgumentParser(description="Self-improvement step for the repository.")

--- a/swe_bench/report.py
+++ b/swe_bench/report.py
@@ -81,17 +81,29 @@ def preds_to_jsonl(dname, predictions):
     return predictions_jsonl
 
 def run_evals(predictions_jsonl, run_id, dataset_name, root_dir, output_dir, num_eval_procs=5):
-    os.chdir(output_dir)  # switch dir so that things will be saved in the specified output_dir
-    run_evals_cmd = f"""
-python {os.path.join(root_dir, './swe_bench/SWE-bench/swebench/harness/run_evaluation.py')}
-    --dataset_name {dataset_name}
-    --predictions_path {predictions_jsonl}
-    --max_workers {num_eval_procs}
-    --run_id {run_id}
-"""
-    run_evals_cmd = " ".join([line.strip() for line in run_evals_cmd.split() if line.strip()])
-    subprocess.run(run_evals_cmd.split(), check=True)
-    os.chdir(root_dir)  # switch back to the original directory
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    run_evals_cmd = [
+        "python",
+        os.path.join(root_dir, './swe_bench/SWE-bench/swebench/harness/run_evaluation.py'),
+        "--dataset_name",
+        dataset_name,
+        "--predictions_path",
+        predictions_jsonl,
+        "--max_workers",
+        str(num_eval_procs),
+        "--run_id",
+        run_id,
+    ]
+    eval_log_path = output_dir / f"{run_id}_run_evaluation.log"
+    with open(eval_log_path, "w") as eval_log:
+        subprocess.run(
+            run_evals_cmd,
+            check=True,
+            cwd=output_dir,
+            stdout=eval_log,
+            stderr=subprocess.STDOUT,
+        )
 
 def make_report(
         dnames,

--- a/tests/test_dgm_outer.py
+++ b/tests/test_dgm_outer.py
@@ -1,0 +1,97 @@
+import json
+
+from DGM_outer import choose_selfimproves, initialize_run
+
+
+def write_metadata(base_dir, commit_id, overall_performance, parent_commit="initial"):
+    commit_dir = base_dir / commit_id
+    commit_dir.mkdir(parents=True, exist_ok=True)
+    metadata = {
+        "parent_commit": parent_commit,
+        "overall_performance": overall_performance,
+    }
+    (commit_dir / "metadata.json").write_text(json.dumps(metadata))
+
+
+def test_choose_selfimproves_best_prefers_highest_score(tmp_path, monkeypatch):
+    output_dir = tmp_path / "output"
+    write_metadata(
+        output_dir,
+        "initial",
+        {
+            "accuracy_score": 0.1,
+            "total_unresolved_ids": ["initial_issue"],
+            "total_emptypatch_ids": [],
+            "total_resolved_ids": [],
+        },
+    )
+    write_metadata(
+        output_dir,
+        "candidate_low",
+        {
+            "accuracy_score": 0.4,
+            "total_unresolved_ids": ["low_issue"],
+            "total_emptypatch_ids": [],
+            "total_resolved_ids": [],
+        },
+    )
+    write_metadata(
+        output_dir,
+        "candidate_high",
+        {
+            "accuracy_score": 0.9,
+            "total_unresolved_ids": ["high_issue"],
+            "total_emptypatch_ids": [],
+            "total_resolved_ids": [],
+        },
+    )
+    monkeypatch.setattr("random.choice", lambda items: items[0])
+
+    chosen = choose_selfimproves(
+        str(output_dir),
+        ["initial", "candidate_low", "candidate_high"],
+        selfimprove_size=1,
+        method="best",
+        polyglot=True,
+    )
+
+    assert chosen == [("candidate_high", "high_issue")]
+
+
+def test_choose_selfimproves_skips_empty_unresolved_ids(tmp_path, monkeypatch):
+    output_dir = tmp_path / "output"
+    write_metadata(
+        output_dir,
+        "initial",
+        {
+            "accuracy_score": 0.5,
+            "total_unresolved_ids": [],
+            "total_emptypatch_ids": [],
+            "total_resolved_ids": ["resolved_issue"],
+        },
+    )
+    monkeypatch.setattr("random.random", lambda: 1.0)
+
+    chosen = choose_selfimproves(
+        str(output_dir),
+        ["initial"],
+        selfimprove_size=1,
+        method="random",
+        polyglot=False,
+    )
+
+    assert chosen == []
+
+
+def test_initialize_run_polyglot_copies_seed_data_to_initial(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    source_dir = tmp_path / "initial_polyglot"
+    source_dir.mkdir()
+    (source_dir / "metadata.json").write_text("{}")
+
+    output_dir = tmp_path / "output"
+    archive, start_generation = initialize_run(str(output_dir), polyglot=True)
+
+    assert archive == ["initial"]
+    assert start_generation == 0
+    assert (output_dir / "initial" / "metadata.json").exists()

--- a/tests/test_dgm_outer.py
+++ b/tests/test_dgm_outer.py
@@ -1,6 +1,7 @@
+import importlib
 import json
-
-from DGM_outer import choose_selfimproves, initialize_run
+import sys
+from types import SimpleNamespace
 
 
 def write_metadata(base_dir, commit_id, overall_performance, parent_commit="initial"):
@@ -13,7 +14,14 @@ def write_metadata(base_dir, commit_id, overall_performance, parent_commit="init
     (commit_dir / "metadata.json").write_text(json.dumps(metadata))
 
 
+def load_dgm_outer(monkeypatch):
+    sys.modules.pop("DGM_outer", None)
+    monkeypatch.setitem(sys.modules, "self_improve_step", SimpleNamespace(self_improve=lambda **_: None))
+    return importlib.import_module("DGM_outer")
+
+
 def test_choose_selfimproves_best_prefers_highest_score(tmp_path, monkeypatch):
+    dgm_outer = load_dgm_outer(monkeypatch)
     output_dir = tmp_path / "output"
     write_metadata(
         output_dir,
@@ -47,7 +55,7 @@ def test_choose_selfimproves_best_prefers_highest_score(tmp_path, monkeypatch):
     )
     monkeypatch.setattr("random.choice", lambda items: items[0])
 
-    chosen = choose_selfimproves(
+    chosen = dgm_outer.choose_selfimproves(
         str(output_dir),
         ["initial", "candidate_low", "candidate_high"],
         selfimprove_size=1,
@@ -59,6 +67,7 @@ def test_choose_selfimproves_best_prefers_highest_score(tmp_path, monkeypatch):
 
 
 def test_choose_selfimproves_skips_empty_unresolved_ids(tmp_path, monkeypatch):
+    dgm_outer = load_dgm_outer(monkeypatch)
     output_dir = tmp_path / "output"
     write_metadata(
         output_dir,
@@ -72,7 +81,7 @@ def test_choose_selfimproves_skips_empty_unresolved_ids(tmp_path, monkeypatch):
     )
     monkeypatch.setattr("random.random", lambda: 1.0)
 
-    chosen = choose_selfimproves(
+    chosen = dgm_outer.choose_selfimproves(
         str(output_dir),
         ["initial"],
         selfimprove_size=1,
@@ -84,13 +93,14 @@ def test_choose_selfimproves_skips_empty_unresolved_ids(tmp_path, monkeypatch):
 
 
 def test_initialize_run_polyglot_copies_seed_data_to_initial(tmp_path, monkeypatch):
+    dgm_outer = load_dgm_outer(monkeypatch)
     monkeypatch.chdir(tmp_path)
     source_dir = tmp_path / "initial_polyglot"
     source_dir.mkdir()
     (source_dir / "metadata.json").write_text("{}")
 
     output_dir = tmp_path / "output"
-    archive, start_generation = initialize_run(str(output_dir), polyglot=True)
+    archive, start_generation = dgm_outer.initialize_run(str(output_dir), polyglot=True)
 
     assert archive == ["initial"]
     assert start_generation == 0

--- a/tests/test_evo_utils.py
+++ b/tests/test_evo_utils.py
@@ -1,0 +1,29 @@
+from utils.evo_utils import is_compiled_self_improve
+
+
+def test_is_compiled_self_improve_supports_missing_logger_and_issue_counts():
+    metadata = {
+        "overall_performance": {
+            "accuracy_score": 0.5,
+            "total_unresolved_ids": ["issue_b"],
+            "total_resolved_ids": ["issue_a"],
+            "total_emptypatch_ids": [],
+            "total_submitted_instances": 2,
+        }
+    }
+
+    assert is_compiled_self_improve(metadata) is True
+    assert is_compiled_self_improve(metadata, num_swe_issues=[1, 2]) is True
+
+
+def test_is_compiled_self_improve_rejects_missing_required_keys():
+    metadata = {
+        "overall_performance": {
+            "accuracy_score": 0.5,
+            "total_unresolved_ids": ["issue_b"],
+            "total_resolved_ids": ["issue_a"],
+            "total_emptypatch_ids": [],
+        }
+    }
+
+    assert is_compiled_self_improve(metadata) is False

--- a/tests/test_llm_withtools.py
+++ b/tests/test_llm_withtools.py
@@ -1,0 +1,9 @@
+from types import SimpleNamespace
+
+from llm_withtools import check_for_tool_use
+
+
+def test_check_for_tool_use_returns_none_when_openai_response_has_no_function_calls():
+    response = SimpleNamespace(output=[SimpleNamespace(type="message")])
+
+    assert check_for_tool_use(response, model="o3-mini-2025-01-31") is None

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,37 @@
+import os
+from types import SimpleNamespace
+
+from swe_bench.report import run_evals
+
+
+def test_run_evals_uses_subprocess_cwd_without_chdir(tmp_path, monkeypatch):
+    output_dir = tmp_path / "reports"
+    output_dir.mkdir()
+    original_cwd = os.getcwd()
+    recorded = {}
+
+    def fake_run(command, check, cwd, stdout, stderr):
+        recorded["command"] = command
+        recorded["check"] = check
+        recorded["cwd"] = cwd
+        recorded["stderr"] = stderr
+        stdout.write("evaluation complete\n")
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("swe_bench.report.subprocess.run", fake_run)
+
+    run_evals(
+        predictions_jsonl="predictions.jsonl",
+        run_id="run-123",
+        dataset_name="demo-dataset",
+        root_dir="/repo",
+        output_dir=str(output_dir),
+        num_eval_procs=7,
+    )
+
+    assert os.getcwd() == original_cwd
+    assert recorded["check"] is True
+    assert recorded["cwd"] == output_dir
+    assert recorded["command"][0] == "python"
+    assert "--run_id" in recorded["command"]
+    assert (output_dir / "run-123_run_evaluation.log").read_text() == "evaluation complete\n"

--- a/utils/evo_utils.py
+++ b/utils/evo_utils.py
@@ -93,7 +93,11 @@ def get_all_performance(run_keyword, results_dir='./swe_bench'):
     
     return performance_results, overall_performance
 
-def is_compiled_self_improve(metadata, num_swe_issues=[], logger=None):
+def _log_if_possible(logger, message):
+    if logger is not None:
+        logger.info(message)
+
+def is_compiled_self_improve(metadata, num_swe_issues=None, logger=None):
     """
     Checks if the run was properly compiled and 'self-improved' by verifying:
       1. The 'overall_performance' dict has the required keys:
@@ -104,24 +108,31 @@ def is_compiled_self_improve(metadata, num_swe_issues=[], logger=None):
     Returns True if all conditions are met, else False.
     """
     overall_perf = metadata.get('overall_performance', {})
-    required_keys = ['accuracy_score', 'total_unresolved_ids', 'total_resolved_ids', 'total_emptypatch_ids']
+    required_keys = [
+        'accuracy_score',
+        'total_unresolved_ids',
+        'total_resolved_ids',
+        'total_emptypatch_ids',
+        'total_submitted_instances',
+    ]
 
     # 1. Must have the required keys
     if not overall_perf or not all(k in overall_perf for k in required_keys):
-        logger.info(f"no required keys")
+        _log_if_possible(logger, "no required keys")
         return False
 
     # 2. Must have at least one non-empty patch
     num_resolved = len(overall_perf['total_resolved_ids'])
     num_unresolved = len(overall_perf['total_unresolved_ids'])
     if (num_resolved + num_unresolved) == 0:
-        logger.info(f"no non-empty patch")
+        _log_if_possible(logger, "no non-empty patch")
         return False
 
     # 3. If specified, total evaluated must match num_swe_issues, else it means that some didn't compile
     total_evaluated = overall_perf['total_submitted_instances']
-    if total_evaluated < num_swe_issues[0]:
-        logger.info(f"not match num_issues")
+    min_expected_issues = min(num_swe_issues) if num_swe_issues else 0
+    if total_evaluated < min_expected_issues:
+        _log_if_possible(logger, "not match num_issues")
         return False
 
     return True


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix DGM outer-loop control path bugs and add reproducible selection seeding
- add structured self-improve status, phase timing, correlation, and error metadata
- make SWE report evaluation safer under parallelism and add focused regression coverage

## Review findings addressed
### Performance
- removed repeated per-future `get_full_eval_threshold` recomputation by hoisting it once per generation
- enabled actual threshold-based full evaluation gating in `self_improve_step.py`
- replaced thread-unsafe `os.chdir()` usage in `swe_bench/report.py` with subprocess `cwd`

### Observability
- record `dgm_run_id`, `generation`, status, start/finish timestamps, phase timings, and structured errors in self-improve metadata
- record failed child attempts in `dgm_metadata.jsonl`
- capture `run_evaluation.py` output into per-run log files

### Steerability
- fixed broken `--choose_selfimproves_method` choices so `best` is selectable
- fixed best-parent ordering to prefer highest scores
- added `--seed` for reproducible selection
- fixed empty unresolved-entry handling to avoid crashing selection loops
- hardened OpenAI tool-call parsing when no function call is present

## Testing
- `python3 -m pytest tests/test_dgm_outer.py tests/test_evo_utils.py tests/test_report.py tests/test_llm_withtools.py`
- `python3 -m py_compile DGM_outer.py self_improve_step.py llm_withtools.py swe_bench/report.py utils/evo_utils.py`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0f8f697-3f9a-4c68-b68c-112839465dd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0f8f697-3f9a-4c68-b68c-112839465dd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

